### PR TITLE
Streamline dedicated.cfg (Map rotations)

### DIFF
--- a/localappdata/Plutonium/storage/t6/dedicated.cfg
+++ b/localappdata/Plutonium/storage/t6/dedicated.cfg
@@ -7,34 +7,7 @@
 // Remove "//" in front of lines to allow the    //
 // server to read them.                          //
 // Anything after "//" is a comment.             //
-//////////////////////////////////////////////////
-// GAME TYPE CONFIGURATION                      //
-//////////////////////////////////////////////////
-// conf - Kill Confirmed                        //
-// ctf - Capture the Flag                       //
-// dem - Demolition                             //
-// dm - Free-for-all                            //
-// dom - Domination                             //
-// gun - Gun Game                               //
-// hq - Headquarters                            //
-// koth - Hardpoint                             //
-// oic - One in the chamber                     //
-// oneflag - One-Flag CTF                       //
-// sas - Sticks & Stones                        //
-// sd - Search and Destroy                      //
-// shrp - Sharpshooter                          //
-// tdm - Team Deathmatch                        //
-//////////////////////////////////////////////////
-// These config files cannot be edited and are  //
-// packed into the .ff files of the game.       //
-// Please make sure the game types are synced   //
-// or you might end up with a FFA that needs    //
-// 7500 kills to be won. YOU HAVE BEEN WARNED!  //
-//////////////////////////////////////////////////
-exec gamesettings_default.cfg                   // Load the default game settings shared by all game modes
-exec gamesettings_tdm.cfg                       // Load the default tdm settings
-set_gametype tdm                                // Set the game type to tdm
-//////////////////////////////////////////////////
+///////////////////////////////////////////////////
 
 //////////////////////////////////////////////////
 // GENERAL CONFIGURATION                        //
@@ -208,82 +181,85 @@ rcon_password ""                                // RemoteCONtrol password. !!Do 
 //restrict_item "bonuscard_danger_close"        // Danger Close - Take a second lethal.
 //////////////////////////////////////////////////
 
-//////////////////////////////////////////////////
-// MAP ROTATION LIST                            //
-//////////////////////////////////////////////////
-// STOCK                                        //
-//////////////////////////////////////////////////
-//                                              //
-// mp_la                - Aftermath             //
-// mp_dockside          - Cargo                 //
-// mp_carrier           - Carrier               //
-// mp_drone             - Drone                 //
-// mp_express           - Express               //
-// mp_hijacked          - Hijacked              //
-// mp_meltdown          - Meltdown              //
-// mp_overflow          - Overflow              //
-// mp_nightclub         - Plaza                 //
-// mp_raid              - Raid                  //
-// mp_slums             - Slums                 //
-// mp_village           - Standoff              //
-// mp_turbine           - Turbine               //
-// mp_socotra           - Yemen                 //
-//                                              //
-// Bonus Map:                                   //
-// mp_nuketown_2020     - Nuketown 2025         //
-//                                              //
-//////////////////////////////////////////////////
-// REVOLUTION MAP PACK 1                        //
-//////////////////////////////////////////////////
-//                                              //
-// mp_downhill          - Downhill              //
-// mp_mirage            - Mirage                //
-// mp_hydro             - Hydro                 //
-// mp_skate             - Grind                 //
-//                                              //
-//////////////////////////////////////////////////
-// UPRISING MAP PACK 2                          //
-//////////////////////////////////////////////////
-//                                              //
-// mp_concert           - Encore                //
-// mp_magma             - Magma                 //
-// mp_vertigo           - Vertigo               //
-// mp_studio            - Studio                //
-//                                              //
-//////////////////////////////////////////////////
-// VENGEANCE MAP PACK 3                         //
-//////////////////////////////////////////////////
-//                                              //
-// mp_uplink            - Uplink                //
-// mp_bridge            - Detour                //
-// mp_castaway          - Cove                  //
-// mp_paintball         - Rush                  //
-//                                              //
-//////////////////////////////////////////////////
-// APOCALYPSE MAP PACK 4                        //
-//////////////////////////////////////////////////
-//                                              //
-// mp_dig               - Dig                   //
-// mp_frostbite         - Frost                 //
-// mp_pod               - Pod                   //
-// mp_takeoff           - Takeoff               //
-//                                              //
-//////////////////////////////////////////////////
-//////////////////////////////////////////////////
-// Examples for sv_maprotation                  //
+//////////////////////////////////////////////////////////////////////////
+// MAP ROTATION CONFIGURATION                                           //
+//////////////////////////////////////////////////////////////////////////
+// GAME TYPE LIST                                                       //
+//////////////////////////////////////////////////////////////////////////
+// conf - Kill Confirmed                                                //
+// ctf - Capture the Flag                                               //
+// dem - Demolition                                                     //
+// dm - Free-for-all                                                    //
+// dom - Domination                                                     //
+// gun - Gun Game                                                       //
+// hq - Headquarters                                                    //
+// koth - Hardpoint                                                     //
+// oic - One in the chamber                                             //
+// oneflag - One-Flag CTF                                               //
+// sas - Sticks & Stones                                                //
+// sd - Search and Destroy                                              //
+// shrp - Sharpshooter                                                  //
+// tdm - Team Deathmatch                                                //
+//////////////////////////////////////////////////////////////////////////
+// MAP LIST                                                             //
+//////////////////////////////////////////////////////////////////////////
+// mp_la                - Aftermath                                     //
+// mp_dockside          - Cargo                                         //
+// mp_carrier           - Carrier                                       //
+// mp_drone             - Drone                                         //
+// mp_express           - Express                                       //
+// mp_hijacked          - Hijacked                                      //
+// mp_meltdown          - Meltdown                                      //
+// mp_overflow          - Overflow                                      //
+// mp_nightclub         - Plaza                                         //
+// mp_raid              - Raid                                          //
+// mp_slums             - Slums                                         //
+// mp_village           - Standoff                                      //
+// mp_turbine           - Turbine                                       //
+// mp_socotra           - Yemen                                         //
+// Bonus Map:                                                           //
+// mp_nuketown_2020     - Nuketown 2025                                 //
+//////////////////////////////////////////////////////////////////////////
+// REVOLUTION MAP PACK 1                                                //
+//////////////////////////////////////////////////////////////////////////
+// mp_downhill          - Downhill                                      //
+// mp_mirage            - Mirage                                        //
+// mp_hydro             - Hydro                                         //
+// mp_skate             - Grind                                         //
+//////////////////////////////////////////////////////////////////////////
+// UPRISING MAP PACK 2                                                  //
+//////////////////////////////////////////////////////////////////////////
+// mp_concert           - Encore                                        //
+// mp_magma             - Magma                                         //
+// mp_vertigo           - Vertigo                                       //
+// mp_studio            - Studio                                        //
+//////////////////////////////////////////////////////////////////////////
+// VENGEANCE MAP PACK 3                                                 //
+//////////////////////////////////////////////////////////////////////////
+// mp_uplink            - Uplink                                        //
+// mp_bridge            - Detour                                        //
+// mp_castaway          - Cove                                          //
+// mp_paintball         - Rush                                          //
+//////////////////////////////////////////////////////////////////////////
+// APOCALYPSE MAP PACK 4                                                //
+//////////////////////////////////////////////////////////////////////////
+// mp_dig               - Dig                                           //
+// mp_frostbite         - Frost                                         //
+// mp_pod               - Pod                                           //
+// mp_takeoff           - Takeoff                                       //
+//////////////////////////////////////////////////////////////////////////
+// EXAMPLE MAP ROTATIONS                                                //
 //////////////////////////////////////////////////////////////////////////
 // Single Game Mode + Maps:                                             //
-//sv_mapRotation "exec tdm.cfg map mp_dig map mp_raid map mp_express"   //
+// sv_mapRotation "exec tdm.cfg map mp_dig map mp_raid map mp_express"  //
 //                                                                      //
 // Several Mix Game Modes + Maps:                                       //
-//sv_mapRotation "exec tdm.cfg map mp_la exec dm.cfg map mp_dockside"   //
+// sv_mapRotation "exec tdm.cfg map mp_la exec dm.cfg map mp_dockside"  //
+//////////////////////////////////////////////////////////////////////////
+// MAP ROTATION (Edit the below to your liking)                         //
+//////////////////////////////////////////////////////////////////////////
+sv_maprotation "exec tdm.cfg map mp_la map mp_dockside map mp_carrier map mp_drone map mp_express map mp_hijacked map mp_meltdown map mp_overflow map mp_nightclub map mp_raid map mp_slums map mp_village map mp_turbine map mp_socotra map mp_nuketown_2020" // TDM base maps + nuketown rotation
 //////////////////////////////////////////////////////////////////////////
 
-//////////////////////////////////////////////////
-// Current Rotation (Edit to your liking)       //
-//////////////////////////////////////////////////
-
-sv_maprotation "exec tdm.cfg map mp_la map mp_dockside map mp_carrier map mp_drone map mp_express map mp_hijacked map mp_meltdown map mp_overflow map mp_nightclub map mp_raid map mp_slums map mp_village map mp_turbine map mp_socotra map mp_nuketown_2020"
-
-//Congratulations. You reached the end of this file. Leave map_rotate down below or else the server will not start after launch...
+// Congratulations. You reached the end of this file. Leave map_rotate down below or else the server will not start after launch...
 map_rotate


### PR DESCRIPTION
Removed section that exec's gamesettings default and TDM and set gametype. As by default this is already the case and even if you change them to a different gamemode it has no effect and only serves to confuse the user who will expect that changing these values will change the gamemode.
The map list has also been moved to be located next to the map rotation for quick reference as this is where gametype is set.
In summary this should reduce the need for new server owners to seek support from Plutonium and minimise confusion. 